### PR TITLE
Issue 12: Shortcut for Hide My Email - updates settings-urls.md

### DIFF
--- a/settings-urls.md
+++ b/settings-urls.md
@@ -10,6 +10,7 @@
 - iCloud → iCloud Backup: `prefs:root=CASTLE&path=BACKUP` or `prefs:root=APPLE_ACCOUNT&path=ICLOUD_SERVICE/BACKUP`
 - iCloud → Find My: `prefs:root=APPLE_ACCOUNT&path=LOCATION_SHARING`
 - iCloud → Family Sharing: `prefs:root=APPLE_ACCOUNT&path=FAMILY`
+- iCloud → Hide My Email: `prefs:root=APPLE_ACCOUNT&path=ICLOUD_SERVICE/PRIVATE_EMAIL_MANAGE`
 - Wi-Fi: `prefs:root=WIFI`
 - Bluetooth: `prefs:root=Bluetooth`
 - Cellular → (root): `prefs:root=MOBILE_DATA_SETTINGS_ID`


### PR DESCRIPTION
Resolves request in Issue 12, shortcut for Hide My Email.

Shortcut found on reddit in this post, verified as working on iOS 15.5

https://www.reddit.com/r/shortcuts/comments/r9jb0n/comment/hsh4le5/