### PR TITLE
Added Journal

### DIFF
--- a/settings-urls.md
+++ b/settings-urls.md
@@ -348,6 +348,9 @@
 - Health → (root): `prefs:root=HEALTH`
 - Health → Siri & Search: `prefs:root=HEALTH&path=SIRI_AND_SEARCH`
 - Home: `prefs:root=HOMEKIT`
+- Journal → (root): `prefs:root=JOURNAL`
+- Journal → Journaling Schedule: `prefs:root=JOURNAL&path=journalingSchedule`
+- Journal → Lock Journal `prefs:root=JOURNAL&path=lockJournal`
 - Music → (root): `prefs:root=MUSIC`
 - Music → Cellular Data: `prefs:root=MUSIC&path=com.apple.Music%3ACellularData`
 - Music → Dolby Atmos: `prefs:root=MUSIC&path=com.apple.Music%3AAtmos`


### PR DESCRIPTION
Added Journal schemes introduced in iOS 17.2.

- Journal → (root): `prefs:root=JOURNAL`
- Journal → Journaling Schedule: `prefs:root=JOURNAL&path=journalingSchedule`
- Journal → Lock Journal `prefs:root=JOURNAL&path=lockJournal`

Should be noted that these only apply to iOS and not iPadOS (d/t Journal not existing on iPadOS at this time).