### PR TITLE
Add Battery → Charging

### DIFF
--- a/settings-urls-sorted.json
+++ b/settings-urls-sorted.json
@@ -176,7 +176,8 @@
     "Apple Pencil": "prefs:root=Pencil",
     "Battery": {
         "(root)": "prefs:root=BATTERY_USAGE",
-        "Battery Health": "prefs:root=BATTERY_USAGE&path=BATTERY_HEALTH"
+        "Battery Health": "prefs:root=BATTERY_USAGE&path=BATTERY_HEALTH",
+        "Charging": "prefs:root=BATTERY_USAGE&path=CHARGING_OPTIONS_IDENTIFIER"
     },
     "Bluetooth": "prefs:root=Bluetooth",
     "Books": {

--- a/settings-urls.json
+++ b/settings-urls.json
@@ -342,7 +342,8 @@
     "Exposure Notifications": "prefs:root=EXPOSURE_NOTIFICATION",
     "Battery": {
         "(root)": "prefs:root=BATTERY_USAGE",
-        "Battery Health": "prefs:root=BATTERY_USAGE&path=BATTERY_HEALTH"
+        "Battery Health": "prefs:root=BATTERY_USAGE&path=BATTERY_HEALTH",
+        "Charging": "prefs:root=BATTERY_USAGE&path=CHARGING_OPTIONS_IDENTIFIER"
     },
     "Privacy": {
         "(root)": "prefs:root=Privacy",

--- a/settings-urls.md
+++ b/settings-urls.md
@@ -232,6 +232,7 @@
 - Exposure Notifications: `prefs:root=EXPOSURE_NOTIFICATION`
 - Battery → (root): `prefs:root=BATTERY_USAGE`
 - Battery → Battery Health: `prefs:root=BATTERY_USAGE&path=BATTERY_HEALTH`
+- Battery → Charging: `prefs:root=BATTERY_USAGE&path=CHARGING_OPTIONS_IDENTIFIER`
 - Privacy → (root): `prefs:root=Privacy`
 - Privacy → Location Services → (root): `prefs:root=Privacy&path=LOCATION`
 - Privacy → Location Services → Share My Location → (root): `prefs:root=Privacy&path=LOCATION/LOCATION_SHARING`


### PR DESCRIPTION
Added the URL to charge limit page.

(Note: [this feature](https://support.apple.com/en-us/108055) is only for iPhone 15 and later models.)